### PR TITLE
Improve workbench compatibility

### DIFF
--- a/tests/io/test_gifti.py
+++ b/tests/io/test_gifti.py
@@ -231,8 +231,8 @@ class TestGifTI(unittest.TestCase):
             np.testing.assert_array_almost_equal(segmentation.keys,
                                                  loaded.keys)
 
-    def test_vertex_data_save_load(self):
-        """Test saving and loading vertex data"""
+    def test_mesh_vertex_data_save_load(self):
+        """Test saving and loading vertex data in a mesh"""
 
         mesh = minimal_mesh()
 
@@ -257,3 +257,19 @@ class TestGifTI(unittest.TestCase):
             np.testing.assert_array_almost_equal(
                 loaded.vertex_data['b'].data,
                 vertex_data_b.data)
+
+    def test_vertex_data_save(self):
+        """Test saving vertex data"""
+
+        vertex_data = VertexData('test', [0, 1, 2, 3])
+
+        with tempfile.TemporaryDirectory() as directory:
+
+            # Save the vertex data and reload it.
+            filename = os.path.join(directory, 'vertex.func.gii')
+            nimesh.io.gifti.save_vertex_data(filename, vertex_data)
+            loaded = nimesh.io.gifti.load_vertex_data(filename)
+
+            self.assertEqual(vertex_data.name, loaded.name)
+            np.testing.assert_array_almost_equal(
+                vertex_data.data, loaded.data)

--- a/tests/io/test_gifti.py
+++ b/tests/io/test_gifti.py
@@ -7,6 +7,7 @@ import numpy as np
 import nibabel as nib
 import nimesh.io
 from nimesh import AffineTransform, CoordinateSystem, Mesh, Segmentation
+from nimesh import Label
 from nimesh.core import VertexData
 
 
@@ -218,6 +219,10 @@ class TestGifTI(unittest.TestCase):
         """Test saving a loading segmentations."""
 
         segmentation = Segmentation('test', [0, 0, 1, 1, 2, 2, 3, 3])
+        segmentation.add_label(0, Label('unknown'))
+        segmentation.add_label(1, Label('red', (1, 0, 0, 1)))
+        segmentation.add_label(2, Label('green', (0, 1, 0, 1)))
+        segmentation.add_label(3, Label('blue', (0, 0, 1, 1)))
 
         # Work in a temporary directory. This guarantees cleanup even on error.
         with tempfile.TemporaryDirectory() as directory:
@@ -230,6 +235,17 @@ class TestGifTI(unittest.TestCase):
             # The loaded data should match the saved data.
             np.testing.assert_array_almost_equal(segmentation.keys,
                                                  loaded.keys)
+
+            # Verify that the labels where loaded correctly.
+            self.assertEqual(len(loaded.labels), 4)
+            self.assertEqual(loaded.labels[0].name, 'unknown')
+            self.assertTupleEqual(loaded.labels[0].color, (0, 0, 0, 0))
+            self.assertEqual(loaded.labels[1].name, 'red')
+            self.assertTupleEqual(loaded.labels[1].color, (1, 0, 0, 1))
+            self.assertEqual(loaded.labels[2].name, 'green')
+            self.assertTupleEqual(loaded.labels[2].color, (0, 1, 0, 1))
+            self.assertEqual(loaded.labels[3].name, 'blue')
+            self.assertTupleEqual(loaded.labels[3].color, (0, 0, 1, 1))
 
     def test_mesh_vertex_data_save_load(self):
         """Test saving and loading vertex data in a mesh"""

--- a/tests/io/test_gifti.py
+++ b/tests/io/test_gifti.py
@@ -122,6 +122,34 @@ class TestGifTI(unittest.TestCase):
                 loaded.transforms[0].transform_coord_sys,
                 CoordinateSystem.MNI)
 
+    def test_mesh_only_save_load(self):
+        """Test saving and loading the vertices and triangles of a mesh."""
+
+        mesh = minimal_mesh()
+
+        # Add a segmentation.
+        segmentation = Segmentation('seg', [0, 0, 1, 1])
+        mesh.add_segmentation(segmentation)
+
+        # Work in a temporary directory. This guarantees cleanup even on error.
+        with tempfile.TemporaryDirectory() as directory:
+
+            # Save the mesh and reload it.
+            filename = os.path.join(directory, 'mesh.gii')
+            nimesh.io.gifti.save_mesh(filename, mesh)
+            loaded = nimesh.io.load(filename)
+
+            # The coordinate system should not have changed.
+            self.assertEqual(mesh.coordinate_system, loaded.coordinate_system)
+
+            # The loaded data should match the saved data. Because there is no
+            # data manipulation, this should be bit perfect.
+            np.testing.assert_array_equal(mesh.vertices, loaded.vertices)
+            np.testing.assert_array_equal(mesh.triangles, loaded.triangles)
+
+            # The segmentation should not have been saved.
+            self.assertEqual(len(loaded.segmentations), 0)
+
     def test_minimal_save_load(self):
         """Test saving and loading with a minimal mesh."""
 


### PR DESCRIPTION
While `nimesh` supports saving meshes to GIfTI files, the Connectome Workbench application has specific requirements on file formats which `nimesh` does not support.

This merge requests improves compatibility with Connectome Workbench. The most notable is the ability to save vertices and triangles, segmentations, and vertex data in independent files.