### PR TITLE
FEAT: add mesh upsampling and icosphere template

### DIFF
--- a/nimesh/__init__.py
+++ b/nimesh/__init__.py
@@ -5,6 +5,7 @@ import nibabel as nib
 import numpy as np
 from nimesh.core import AffineTransform, CoordinateSystem, Mesh
 from nimesh.core import Label, Segmentation
+from nimesh.core import icosphere
 from nimesh import io
 
 

--- a/nimesh/asarray.py
+++ b/nimesh/asarray.py
@@ -1,4 +1,7 @@
 import numpy as np
+import warnings
+
+from collections import defaultdict
 
 
 def compute_normals(vertices: np.ndarray, faces: np.ndarray) -> np.ndarray:
@@ -43,3 +46,151 @@ def compute_normals(vertices: np.ndarray, faces: np.ndarray) -> np.ndarray:
         normals.append(normal)
 
     return np.array(normals)
+
+
+def icosahedron() -> (np.ndarray, np.ndarray):
+    """ Returns the vertices and the triangles of a regular icosahedron
+    inscribed in a icosphere of radius 1 centered at the origin.
+
+    Returns:
+        vertices: A 2D numpy array with a shape of (M, 3) that
+            contains the vertices of the icosahedron.
+        faces: A 2D numpy array with a shape of (N, 3) that
+            contains the faces of the icosahedron.
+
+    """
+    t = (1.0 + np.sqrt(5.0)) / 2.0
+    vertices = [[-1, t, 0],
+                [1, t, 0],
+                [-1, -t, 0],
+                [1, -t, 0],
+                [0, -1, t],
+                [0, 1, t],
+                [0, -1, -t],
+                [0, 1, -t],
+                [t, 0, -1],
+                [t, 0, 1],
+                [-t, 0, -1],
+                [-t, 0, 1]]
+
+    triangles = [[0, 11, 5],
+                 [0, 5, 1],
+                 [0, 1, 7],
+                 [0, 7, 10],
+                 [0, 10, 11],
+                 [1, 5, 9],
+                 [5, 11, 4],
+                 [11, 10, 2],
+                 [10, 7, 6],
+                 [7, 1, 8],
+                 [3, 9, 4],
+                 [3, 4, 2],
+                 [3, 2, 6],
+                 [3, 6, 8],
+                 [3, 8, 9],
+                 [4, 9, 5],
+                 [2, 4, 11],
+                 [6, 2, 10],
+                 [8, 6, 7],
+                 [9, 8, 1]]
+
+    vertices = project_to_sphere(np.asarray(vertices))
+    triangles = np.asarray(triangles)
+    return vertices, triangles
+
+
+def project_to_sphere(vertices: np.ndarray) -> np.ndarray:
+    """ Computes the projection of the vertices of a mesh onto a icosphere of
+    radius 1 centered at the origin.
+
+    Args:
+        vertices: A 2D numpy array with a shape of (N, 3)
+            where N is the number of vertices.
+
+    Returns:
+        projected_vertices: A 2D numpy array with a shape of (N, 3) that
+            contains the coordinates of the projection of each vertex in the
+            same order as the input.
+
+    Warnings:
+        RuntimeWarning if one of the vertices has norm equal to zero
+
+    """
+    projected_vertices = np.zeros((len(vertices), 3))
+    for k, v in enumerate(vertices):
+        norm = np.linalg.norm(v)
+        if norm == 0:
+            warnings.warn('Trying to project a point with zero norm.',
+                          RuntimeWarning)
+            projected_vertices[k, :] = np.asarray(v)
+        else:
+            projected_vertices[k, :] = np.asarray(v) / norm
+    return projected_vertices
+
+
+def upsample(vertices: np.ndarray, triangles: np.ndarray) -> (
+        np.ndarray, np.ndarray):
+    """ Upsamples each triangle of a mesh
+
+    |\                |\
+    |  \              |  \
+    |    \      -->   |----\
+    |      \          | \  | \
+    |________\        |__ \|__ \
+
+    The upsampling strategy defines three new vertices for every face of the
+    initial mesh. Each of these new vertices correspond to the middle point of
+    one edge of the original triangle. Finally, a new covering of the original
+    face is determined with the 6 points.
+
+    The upsampling factor of the triangles is four.
+
+    Args:
+        vertices: A 2D numpy array with a shape of (N, 3)
+            where N is the number of vertices.
+        triangles: A 2D numpy array with a shape of (M, 3)
+            where M is the number of faces.
+
+    Returns:
+        vertices: A 2D numpy array with a shape of (K, 3)
+            where K is the number of vertices after upsampling.
+        faces: A 2D numpy array with a shape of (4*M, 3)
+            where M is the number of faces before upsampling.
+
+    """
+    upsampled_vertices = [list(v) for v in vertices]
+
+    processed_points = defaultdict()
+
+    def index_middle_point(point_1, point_2):
+        # Given the indices of two points, it returns the index of the middle
+        # point
+        # Check if the edge has already been cut in two
+        key = tuple(sorted([point_1, point_2]))
+        if key in processed_points:
+            return processed_points[key]
+        else:
+            vertex1 = upsampled_vertices[point_1]
+            vertex2 = upsampled_vertices[point_2]
+
+            middle = (np.asarray(vertex1) + np.asarray(vertex2)) / 2.0
+            upsampled_vertices.append(list(middle))
+
+            index = len(upsampled_vertices) - 1
+            processed_points[key] = index
+            return index
+
+    upsampled_triangles = []
+    for face in triangles:
+        idx1, idx2, idx3 = face
+
+        mid12 = index_middle_point(idx1, idx2)
+        mid13 = index_middle_point(idx1, idx3)
+        mid23 = index_middle_point(idx2, idx3)
+
+        upsampled_triangles.append([idx1, mid12, mid13])
+        upsampled_triangles.append([idx2, mid12, mid23])
+        upsampled_triangles.append([idx3, mid13, mid23])
+        upsampled_triangles.append([mid12, mid13, mid23])
+
+    return np.array(upsampled_vertices), np.array(upsampled_triangles)

--- a/nimesh/core.py
+++ b/nimesh/core.py
@@ -2,6 +2,7 @@ import numpy as np
 from enum import IntEnum
 from typing import List, Sequence, Union
 
+from .asarray import icosahedron, project_to_sphere, upsample
 from .mixins import Named, ListOfNamed
 
 
@@ -579,3 +580,27 @@ class VertexData(Named):
     def nb_vertices(self):
         """Returns the number of vertices associated with the data"""
         return len(self.data)
+
+
+def icosphere(n: int = 0) -> Mesh:
+    """ Returns a icosphere of radius 1.
+
+    Args:
+        n: a non-negative integer that defines how many times the icosahedron
+            will be upsampled.
+
+    Returns:
+        sphere: A Mesh object that defines the wanted icosphere.
+
+    Raises:
+        ValueError if `n` is not a non-negative integer.
+
+    """
+    n = int(n)
+    if n < 0:
+        raise ValueError('The number of upsamplings must be non negative.')
+    v, t = icosahedron()
+    for k in range(n):
+        v, t = upsample(v, t)
+    v = project_to_sphere(v)
+    return Mesh(v, t)

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -1,0 +1,82 @@
+import unittest
+
+import numpy as np
+
+from collections import defaultdict
+from nimesh.asarray import icosahedron, project_to_sphere, upsample
+from nimesh.core import icosphere
+
+
+class TestIcosahedron(unittest.TestCase):
+    """Test the nimesh.asarray.icosahedron method."""
+
+    def test_polyhedron(self):
+        vertices, triangles = icosahedron()
+
+        self.assertEqual(vertices.shape[0], 12)
+        self.assertEqual(triangles.shape[0], 20)
+
+        edges = defaultdict()
+        for t in triangles:
+            e1 = tuple(sorted([t[0], t[1]]))
+            e2 = tuple(sorted([t[0], t[2]]))
+            e3 = tuple(sorted([t[1], t[2]]))
+            if e1 not in edges:
+                edges[e1] = True
+            if e2 not in edges:
+                edges[e2] = True
+            if e3 not in edges:
+                edges[e3] = True
+
+        # Check Euler's formula
+        self.assertEqual(len(vertices) - len(edges.keys()) + len(triangles), 2)
+
+        # Check regularity on edges
+        edge_length = []
+        for e in edges.keys():
+            edge_length.append(np.linalg.norm(vertices[e[0]] - vertices[e[1]]))
+
+        self.assertEqual(len(np.unique(edge_length)), 1)
+
+
+class TestProjectOnSphere(unittest.TestCase):
+    def test_warning(self):
+        with self.assertWarns(RuntimeWarning):
+            project_to_sphere(np.array([[0, 0, 0]]))
+
+    def test_on_random_points(self):
+        vertices = np.random.rand(20, 3).astype(np.float32)
+        pv = project_to_sphere(vertices)
+
+        norms = np.linalg.norm(pv, axis=1)
+        np.testing.assert_almost_equal(norms, np.ones(vertices.shape[0]))
+
+    def test_on_upsampled_icosahedron(self):
+        vv, tt = upsample(*icosahedron())
+        pv = project_to_sphere(vv)
+
+        norms = np.linalg.norm(pv, axis=1)
+        np.testing.assert_almost_equal(norms, np.ones(vv.shape[0]))
+
+
+class TestSphere(unittest.TestCase):
+    def test_default(self):
+        my_sphere = icosphere()
+        ico_v, ico_t = icosahedron()
+
+        np.testing.assert_almost_equal(my_sphere.vertices, ico_v)
+        np.testing.assert_almost_equal(my_sphere.triangles, ico_t)
+
+    def test_upsampled(self):
+        n = np.random.randint(1, 5)
+        my_sphere = icosphere(n)
+
+        self.assertEqual(20 * (4 ** n), my_sphere.triangles.shape[0])
+
+        norms = np.linalg.norm(my_sphere.vertices, axis=1)
+        np.testing.assert_almost_equal(norms,
+                                       np.ones(my_sphere.vertices.shape[0]))
+
+    def test_error(self):
+        with self.assertRaises(ValueError):
+            icosphere(-1)


### PR DESCRIPTION
This PR adds the possibility to upsample a mesh and to get a template icosphere mesh.

The corresponding tests and docstrings are added.